### PR TITLE
Add syntax highlighting for CloudFormation json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # aws-vim
-Plugin acts as a completion helper for Cloud Formation Templates.
+Plugin acts as a completion helper for Cloud Formation Templates, and provides
+some basic syntax highlighting to help those tasked with reading templates.
 
 Currently this is a very early version, use it on your own risk. 
 

--- a/syntax/aws.vim
+++ b/syntax/aws.vim
@@ -34,6 +34,8 @@ syn keyword Keyword containedin=ALL
       \ Properties
       \ Label
       \ TemplateURL
+      \ Resources
+
 
 hi def link ref Special
 hi def link fn Function

--- a/syntax/aws.vim
+++ b/syntax/aws.vim
@@ -1,0 +1,41 @@
+" Vim syntax file
+" Language:     AWS CloudFormation Templates (cft)
+" Last Change:  2016 Sept 14
+"
+" Maintainer:   Andrew Stuart <andrew.stuart2@gmail.com>
+
+" Type definitions
+syn match typeDec /"Type"\s*:\s*"*/  nextgroup=type containedin=ALL
+syn match   type           /\(\w\|:\)\+/ contained
+
+" Reference object
+syn match   ref          /{\s*"Ref"\s*:\_.\{-}}/
+
+" Functions and predefined AWS
+syn match   fn     /Fn::\w\+/ containedin=ALL
+syn match   predef   /AWS::\(\w\|:\)\+/ containedin=ALL
+
+" "Keywords"
+syn keyword Keyword containedin=ALL
+      \ AWSTemplateFormatVersion
+      \ ConstraintDescription
+      \ NoEcho
+      \ Type
+      \ Ref
+      \ Default
+      \ Description
+      \ MinLength
+      \ MaxLength
+      \ AllowedPattern
+      \ AllowedValues
+      \ Metadata
+      \ Parameters
+      \ Outputs
+      \ Properties
+      \ Label
+      \ TemplateURL
+
+hi def link ref Special
+hi def link fn Function
+hi def link predef Constant
+hi def link type Type

--- a/syntax/aws.vim
+++ b/syntax/aws.vim
@@ -16,7 +16,7 @@ syn match   fn     /Fn::\w\+/ containedin=ALL
 syn match   predef   /AWS::\(\w\|:\)\+/ containedin=ALL
 
 " "Keywords"
-syn keyword Keyword containedin=ALL
+syn keyword Keyword containedin=jsonKeyword
       \ AWSTemplateFormatVersion
       \ ConstraintDescription
       \ NoEcho

--- a/syntax/aws.vim
+++ b/syntax/aws.vim
@@ -4,9 +4,10 @@
 "
 " Maintainer:   Andrew Stuart <andrew.stuart2@gmail.com>
 
+runtime! syntax/json.vim
+
 " Type definitions
-syn match typeDec /"Type"\s*:\s*"*/  nextgroup=type containedin=ALL
-syn match   type           /\(\w\|:\)\+/ contained
+syn match type /"Type"\s*:\s*".\{-}"/  containedin=topjsonObject
 
 " Reference object
 syn match   ref          /{\s*"Ref"\s*:\_.\{-}}/
@@ -41,3 +42,5 @@ hi def link ref Special
 hi def link fn Function
 hi def link predef Constant
 hi def link type Type
+
+let b:current_syntax="aws"


### PR DESCRIPTION
This is just something I wanted to have when looking at CloudFormation templates, since they can be pretty darn hard to follow without some visual cues. It's by no means comprehensive, but I at least tested it with vim-json and without it, to make sure it worked well in both places.
